### PR TITLE
feat : 잔디 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "cmdk": "^0.2.1",
         "date-fns": "^3.3.1",
         "dayjs": "^1.11.10",
+        "embla-carousel-react": "^8.0.0",
         "lucide-react": "^0.321.0",
         "next": "14.1.0",
         "next-themes": "^0.2.1",
@@ -2575,6 +2576,31 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.651.tgz",
       "integrity": "sha512-jjks7Xx+4I7dslwsbaFocSwqBbGHQmuXBJUK9QBZTIrzPq3pzn6Uf2szFSP728FtLYE3ldiccmlkOM/zhGKCpA==",
       "dev": true
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.0.0.tgz",
+      "integrity": "sha512-ecixcyqS6oKD2nh5Nj5MObcgoSILWNI/GtBxkidn5ytFaCCmwVHo2SecksaQZHcARMMpIR2dWOlSIdA1LkZFUA=="
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.0.0.tgz",
+      "integrity": "sha512-qT0dii8ZwoCtEIBE6ogjqU2+5IwnGfdt2teKjCzW88JRErflhlCpz8KjWnW8xoRZOP8g0clRtsMEFoAgS/elfA==",
+      "dependencies": {
+        "embla-carousel": "8.0.0",
+        "embla-carousel-reactive-utils": "8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.0.0.tgz",
+      "integrity": "sha512-JCw0CqCXI7tbHDRogBb9PoeMLyjEC1vpN0lDOzUjmlfVgtfF+ffLaOK8bVtXVUEbNs/3guGe3NSzA5J5aYzLzw==",
+      "peerDependencies": {
+        "embla-carousel": "8.0.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cmdk": "^0.2.1",
     "date-fns": "^3.3.1",
     "dayjs": "^1.11.10",
+    "embla-carousel-react": "^8.0.0",
     "lucide-react": "^0.321.0",
     "next": "14.1.0",
     "next-themes": "^0.2.1",

--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from "react";
 
 export default function Footer() {
   return (
@@ -21,16 +21,8 @@ export default function Footer() {
               github
             </a>
           </li>
-          <li>
-            <a
-              href="https://github.com/orgs/iburnhub/repositories"
-              className="hover:underline"
-            >
-              Contact
-            </a>
-          </li>
         </ul>
       </div>
     </footer>
-  )
+  );
 }

--- a/src/app/navBar.tsx
+++ b/src/app/navBar.tsx
@@ -24,59 +24,8 @@ export default function NavBar() {
           </span>
         </Link>
         <NavSearchBar />
-        <button
-          data-collapse-toggle="navbar-default"
-          type="button"
-          className="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600"
-          aria-controls="navbar-default"
-          aria-expanded="false"
-        >
-          <span className="sr-only">Open main menu</span>
-          <svg
-            className="w-5 h-5"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 17 14"
-          >
-            <path
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M1 1h15M1 7h15M1 13h15"
-            />
-          </svg>
-        </button>
         <div className="hidden w-full md:block md:w-auto" id="navbar-default">
-          <ul className="font-medium flex flex-col p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:flex-row md:space-x-8 rtl:space-x-reverse md:mt-0 md:border-0 md:bg-white dark:bg-gray-800 md:dark:bg-gray-900 dark:border-gray-700 items-center">
-            {/*<li>*/}
-            {/*  <a*/}
-            {/*    href="#"*/}
-            {/*    className="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0 dark:text-white md:dark:text-blue-500"*/}
-            {/*    aria-current="page"*/}
-            {/*  >*/}
-            {/*    Home*/}
-            {/*  </a>*/}
-            {/*</li>*/}
-            {/*<li>*/}
-            {/*  <a*/}
-            {/*    href="#"*/}
-            {/*    className="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent"*/}
-            {/*  >*/}
-            {/*    About*/}
-            {/*  </a>*/}
-            {/*</li>*/}
-            <li>
-              <a
-                href="#"
-                className="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent"
-              >
-                Contact
-              </a>
-            </li>
-            <ModeToggle />
-          </ul>
+          <ModeToggle />
         </div>
       </div>
     </nav>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,12 +3,9 @@ import MainSearchBar from "@/app/mainSearchBar";
 export default function Home() {
   return (
     <div className="w-full flex flex-col items-center justify-center">
-      <h1 className="mt-28 font-[GMARKET-Bold] scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-7xl mb-6">
+      <h1 className="mt-36 mb-28 font-[GMARKET-Bold] scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-7xl">
         mejai.gg
       </h1>
-      <blockquote className="text-xl italic font-semibold text-gray-900 dark:text-white mb-6">
-        {/*<p>슈우웃</p>*/}
-      </blockquote>
       <MainSearchBar />
     </div>
   );

--- a/src/app/summoner-page/LazyLoadedMonthMejaiCard.tsx
+++ b/src/app/summoner-page/LazyLoadedMonthMejaiCard.tsx
@@ -36,9 +36,9 @@ export default function LazyLoadedMonthMejaiCard({
       {isVisible ? (
         <Card>
           <CardContent className="flex flex-col aspect-square items-center justify-center p-6">
-            <span className="text-4xl font-semibold mb-5">{month}월</span>
             {/* 실제 컴포넌트 로딩 */}
             <MonthMejaiCard month={month} />
+            <span className="text-2xl font-semibold mt-4">{month}월</span>
           </CardContent>
         </Card>
       ) : (

--- a/src/app/summoner-page/LazyLoadedMonthMejaiCard.tsx
+++ b/src/app/summoner-page/LazyLoadedMonthMejaiCard.tsx
@@ -36,7 +36,6 @@ export default function LazyLoadedMonthMejaiCard({
       {isVisible ? (
         <Card>
           <CardContent className="flex flex-col aspect-square items-center justify-center p-6">
-            {/* 실제 컴포넌트 로딩 */}
             <MonthMejaiCard month={month} />
             <span className="text-2xl font-semibold mt-4">{month}월</span>
           </CardContent>
@@ -44,7 +43,7 @@ export default function LazyLoadedMonthMejaiCard({
       ) : (
         <div className="flex justify-center items-center w-[320px] h-[320px]">
           Loading...
-        </div> // 여기에 스피너 컴포넌트를 넣을 수 있습니다.
+        </div>
       )}
     </div>
   );

--- a/src/app/summoner-page/LazyLoadedMonthMejaiCard.tsx
+++ b/src/app/summoner-page/LazyLoadedMonthMejaiCard.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import MonthMejaiCard from "@/app/summoner-page/monthMejaiCard";
+
+interface LazyLoadedMonthMejaiCardProps {
+  month: number;
+}
+export default function LazyLoadedMonthMejaiCard({
+  month,
+}: LazyLoadedMonthMejaiCardProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries;
+      if (entry.isIntersecting) {
+        setIsVisible(true);
+        observer.disconnect();
+      }
+    });
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) {
+        observer.unobserve(ref.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div ref={ref} style={{ minHeight: "100px" }}>
+      {isVisible ? (
+        <Card>
+          <CardContent className="flex flex-col aspect-square items-center justify-center p-6">
+            <span className="text-4xl font-semibold mb-5">{month}월</span>
+            {/* 실제 컴포넌트 로딩 */}
+            <MonthMejaiCard month={month} />
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="flex justify-center items-center w-[320px] h-[320px]">
+          Loading...
+        </div> // 여기에 스피너 컴포넌트를 넣을 수 있습니다.
+      )}
+    </div>
+  );
+}

--- a/src/app/summoner-page/fetchFunc.tsx
+++ b/src/app/summoner-page/fetchFunc.tsx
@@ -13,3 +13,17 @@ export const fetchUserInfo = async ({
   );
   return response.data;
 };
+
+export const fetchJandi = async ({
+  queryKey,
+}: {
+  queryKey: [string, { id: string; tag: string; year: number; month: number }];
+}) => {
+  console.log(queryKey);
+  const [_key, { id, tag, year, month }] = queryKey;
+  // if (!id) return null;
+  const response = await axios.get(
+    `${SERVER_URL}/users/streak?id=${id}&tag=${tag}&year=${year}&month=${month}`,
+  );
+  return response.data;
+};

--- a/src/app/summoner-page/jandiBox.tsx
+++ b/src/app/summoner-page/jandiBox.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+  Carousel,
+  CarouselApi,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
+import { useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import MejaiBox from "@/app/summoner-page/mejaiBox";
+
+export default function JandiBox() {
+  const [api, setApi] = useState<CarouselApi>();
+  const [current, setCurrent] = useState(0);
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+
+    setCount(api.scrollSnapList().length);
+    setCurrent(api.selectedScrollSnap() + 1);
+
+    api.on("select", () => {
+      setCurrent(api.selectedScrollSnap() + 1);
+    });
+  }, [api]);
+  return (
+    <div className=" flex justify-center flex-col items-center">
+      <Carousel setApi={setApi} className="w-full max-w-xs">
+        <CarouselContent>
+          {Array.from({ length: 5 }).map((_, index) => (
+            <CarouselItem key={index}>
+              <Card>
+                <CardContent className="flex flex-col aspect-square items-center justify-center p-6">
+                  <span className="text-4xl font-semibold mb-5">
+                    {index + 1}월
+                  </span>
+                  <div className="grid grid-cols-7 gap-1">
+                    {Array.from({ length: 31 }).map((_, index) => (
+                      <MejaiBox key={index} index={index} />
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+      <div className="py-2 text-center text-sm text-muted-foreground">
+        {current} of {count}
+      </div>
+    </div>
+  );
+}

--- a/src/app/summoner-page/jandiBox.tsx
+++ b/src/app/summoner-page/jandiBox.tsx
@@ -1,61 +1,34 @@
 "use client";
 
+import React, { useState, useEffect, useRef } from "react";
 import {
   Carousel,
-  CarouselApi,
   CarouselContent,
   CarouselItem,
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
-import { useEffect, useState } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import MejaiBox from "@/app/summoner-page/mejaiBox";
+import LazyLoadedMonthMejaiCard from "@/app/summoner-page/LazyLoadedMonthMejaiCard";
 
 export default function JandiBox() {
-  const [api, setApi] = useState<CarouselApi>();
-  const [current, setCurrent] = useState(0);
-  const [count, setCount] = useState(0);
+  const nowMonth = new Date().getMonth() + 1;
 
-  useEffect(() => {
-    if (!api) {
-      return;
-    }
-
-    setCount(api.scrollSnapList().length);
-    setCurrent(api.selectedScrollSnap() + 1);
-
-    api.on("select", () => {
-      setCurrent(api.selectedScrollSnap() + 1);
-    });
-  }, [api]);
   return (
-    <div className=" flex justify-center flex-col items-center">
-      <Carousel setApi={setApi} className="w-full max-w-xs">
+    <div className="flex justify-center flex-col items-center">
+      <Carousel
+        opts={{ align: "center", loop: true, startIndex: nowMonth - 1 }}
+        className="w-full max-w-xs"
+      >
         <CarouselContent>
-          {Array.from({ length: 5 }).map((_, index) => (
+          {Array.from({ length: nowMonth }).map((_, index) => (
             <CarouselItem key={index}>
-              <Card>
-                <CardContent className="flex flex-col aspect-square items-center justify-center p-6">
-                  <span className="text-4xl font-semibold mb-5">
-                    {index + 1}월
-                  </span>
-                  <div className="grid grid-cols-7 gap-1">
-                    {Array.from({ length: 31 }).map((_, index) => (
-                      <MejaiBox key={index} index={index} />
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
+              <LazyLoadedMonthMejaiCard month={index + 1} />
             </CarouselItem>
           ))}
         </CarouselContent>
         <CarouselPrevious />
         <CarouselNext />
       </Carousel>
-      <div className="py-2 text-center text-sm text-muted-foreground">
-        {current} of {count}
-      </div>
     </div>
   );
 }

--- a/src/app/summoner-page/mejaiBox.tsx
+++ b/src/app/summoner-page/mejaiBox.tsx
@@ -24,8 +24,9 @@ export default function MejaiBox({ index }: { index: number }) {
               />
             </div>
           </HoverCardTrigger>
-          <HoverCardContent className="HoverCardContent font-[BFL-B]">
-            1월 27일 3승 3패
+          <HoverCardContent className="HoverCardContent flex flex-col items-center justify-center">
+            <p>1월 27일</p>
+            <p>3승 3패</p>
           </HoverCardContent>
         </HoverCard>
       ) : (

--- a/src/app/summoner-page/mejaiBox.tsx
+++ b/src/app/summoner-page/mejaiBox.tsx
@@ -5,16 +5,19 @@ import {
 } from "@/components/ui/hover-card";
 
 import Image from "next/image";
+interface MejaiBoxProps {
+  date: string;
+  gameCount: number;
+}
 
-export default function MejaiBox({ index }: { index: number }) {
+export default function MejaiBox({ date, gameCount }: MejaiBoxProps) {
   return (
     <>
-      {index % 3 === 0 ? (
+      {gameCount !== 0 ? (
         <HoverCard openDelay={0} closeDelay={0}>
           <HoverCardTrigger>
             <div className="relative m-0.5">
               <Image
-                key={index}
                 draggable={false}
                 src="/mejai.png"
                 alt="Mejai's Soulstealer"
@@ -24,15 +27,14 @@ export default function MejaiBox({ index }: { index: number }) {
               />
             </div>
           </HoverCardTrigger>
-          <HoverCardContent className="HoverCardContent flex flex-col items-center justify-center">
-            <p>1월 27일</p>
-            <p>3승 3패</p>
+          <HoverCardContent className="HoverCardContent flex flex-col items-center justify-center text-xs">
+            <p>{date}</p>
+            <p>{gameCount}판</p>
           </HoverCardContent>
         </HoverCard>
       ) : (
         <div className="relative m-0.5">
           <Image
-            key={index}
             draggable={false}
             src="/empty-item.png"
             alt="Mejai's Soulstealer"

--- a/src/app/summoner-page/monthMejaiCard.tsx
+++ b/src/app/summoner-page/monthMejaiCard.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import MejaiBox from "@/app/summoner-page/mejaiBox";
+import { useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { fetchJandi } from "@/app/summoner-page/fetchFunc";
+import dayjs from "dayjs";
+import { useEffect, useState } from "react";
+import { AxiosError } from "axios";
+interface DayGameData {
+  date: string;
+  gameCount: number;
+}
+
+function updateGameCountForMonth(inputData: DayGameData[], month: number) {
+  const year = 2024;
+
+  // 해당 월의 첫 날과 마지막 날을 dayjs 객체로 생성
+  const startOfMonth = dayjs(new Date(year, month - 1, 1));
+  const endOfMonth = dayjs(new Date(year, month, 0));
+
+  // 해당 월의 모든 날짜를 포함하는 배열 생성
+  let daysArray: DayGameData[] = [];
+  let day = startOfMonth;
+
+  while (day.isBefore(endOfMonth) || day.isSame(endOfMonth, "day")) {
+    daysArray.push({
+      date: day.format("YYYY-MM-DD"),
+      gameCount: 0,
+    });
+    day = day.add(1, "day");
+  }
+
+  // 입력 데이터로 gameCount 업데이트
+  inputData.forEach((data: DayGameData) => {
+    const index = daysArray.findIndex((day) => day.date === data.date);
+    if (index !== -1) {
+      daysArray[index].gameCount = data.gameCount;
+    }
+  });
+
+  return daysArray;
+}
+
+interface MonthMejaiCardProps {
+  month: number;
+}
+
+export default function MonthMejaiCard({ month }: MonthMejaiCardProps) {
+  const [monthData, setMonthData] = useState<DayGameData[]>([]);
+  const params = useSearchParams();
+  const id = params.get("id") || "";
+  const tag = params.get("tag") || "";
+
+  const { data, error, isLoading } = useQuery<DayGameData[]>({
+    queryKey: ["jandi", { id, tag, year: 2024, month: month }],
+    queryFn: fetchJandi,
+    staleTime: 1000 * 60 * 15,
+    gcTime: 1000 * 60 * 15,
+  });
+
+  // useQuery의 결과가 변경될 때마다 monthData 상태를 업데이트합니다.
+  useEffect(() => {
+    if (data) {
+      const updatedData = updateGameCountForMonth(data, month);
+      setMonthData(updatedData);
+      console.log(updatedData);
+    }
+  }, [data]); // data가 변경될 때마다 이 useEffect를 재실행합니다.
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center items-center h-[200px] w-[200px]">
+        Loading...
+      </div>
+    );
+  if (error instanceof AxiosError) return <div>Error...</div>;
+
+  return (
+    <div className="grid grid-cols-7 gap-1">
+      {monthData.map((day, index) => (
+        <MejaiBox key={index} date={day.date} gameCount={day.gameCount} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/summoner-page/page.tsx
+++ b/src/app/summoner-page/page.tsx
@@ -8,7 +8,7 @@ import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { fetchUserInfo } from "@/app/summoner-page/fetchFunc";
 import ErrorPage from "@/app/summoner-page/errorPage";
-
+import JandiBox from "@/app/summoner-page/jandiBox";
 export default function SummonerPage() {
   const params = useSearchParams(); // useRouter 훅 사용
   const id = params.get("id") || ""; // router.query에서 id와 tag 추출
@@ -27,7 +27,8 @@ export default function SummonerPage() {
     <>
       <UserInfoBox id={id} tag={tag} />
       <TierBox id={id} tag={tag} />
-      <Jandi />
+      <JandiBox />
+      {/*<Jandi />*/}
     </>
   );
 }

--- a/src/app/summoner-page/tierBox.tsx
+++ b/src/app/summoner-page/tierBox.tsx
@@ -40,7 +40,7 @@ export default function TierBox({ id, tag }: TierBoxProps) {
   if (error) {
     return (
       <div className="h-32 flex justify-center items-center m-6 p-4 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
-        <span className="text-xl font-[NETMARBLE-Bold]"></span>
+        <span className="text-lg font-[NETMARBLE-Bold]"></span>
       </div>
     );
   }
@@ -56,7 +56,7 @@ export default function TierBox({ id, tag }: TierBoxProps) {
         />
       </div>
       <div className="w-60 h-full flex flex-col justify-center ml-4">
-        <h1 className="font-bold text-2xl">
+        <h1 className="font-bold text-xl">
           {data.tier} {data.rank}
         </h1>
         <h4>{data.leaguePoints}LP</h4>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins
+    )
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+    const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return
+      }
+
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }, [])
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev()
+    }, [api])
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext()
+    }, [api])
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault()
+          scrollPrev()
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault()
+          scrollNext()
+        }
+      },
+      [scrollPrev, scrollNext]
+    )
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return
+      }
+
+      setApi(api)
+    }, [api, setApi])
+
+    React.useEffect(() => {
+      if (!api) {
+        return
+      }
+
+      onSelect(api)
+      api.on("reInit", onSelect)
+      api.on("select", onSelect)
+
+      return () => {
+        api?.off("select", onSelect)
+      }
+    }, [api, onSelect])
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    )
+  }
+)
+Carousel.displayName = "Carousel"
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+CarouselContent.displayName = "CarouselContent"
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+CarouselItem.displayName = "CarouselItem"
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+})
+CarouselPrevious.displayName = "CarouselPrevious"
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+})
+CarouselNext.displayName = "CarouselNext"
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}


### PR DESCRIPTION
## ✅ 풀\_리퀘스트 체크리스트

<!--
하나씩 확인 후 체크박스에 표시해주세요.
-->

- [x] PR 제목: [Feature/Fix/Refactor...] 작업 내용 한 줄 요약 (브랜치 이름) #이슈번호
- [x] commit message 가 적절한지 확인해주세요.
- [x] 적절한 branch 로 요청했는지 확인해주세요.
- [x] Assignees, Label 을 붙여주세요.
- [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer 로 등록해주세요.
- [x] PR이 승인된 경우 해당 브랜치는 삭제해 주세요!

<br/>

## 🔄 변경 사항

<!-- 해당 pr에서 작업한 내역을 적어주세요. 처음엔 간단하게 요약, list 형식으로 세부사항 작성 -->

carousel ui 사용해서 각 유닛별로 LazyLoading 구현했습니다.
- 기존 잔디의 경우 1년치를 받아오면 사용자 입장에서 너무 많은 시간(1개월당 3~ 4초)을 대기하게 되므로 한달 단위로 잘랐습니다.
- carousel 사용해서 월별로 메자이 그림 31개 들어있는 card 만들었습니다.
- 각 card별로 컴포넌트 마운트 되자마자 fetch하면 분할한 의미가 없으므로 lazyloading 도입했습니다.
- IntersectionObserver사용해서 현재 위치 비교 후 useQuery 호출하도록 처리했습니다.

<br/>
closes: #3


<br/>
