### PR TITLE
feat: 북마크 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@radix-ui/react-hover-card": "^1.0.7",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-popover": "^1.0.7",
+        "@radix-ui/react-scroll-area": "^1.0.5",
+        "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
         "@tanstack/react-query": "^5.28.9",
         "@tanstack/react-query-devtools": "^5.28.10",
@@ -488,6 +490,14 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
+      "integrity": "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -1006,6 +1016,60 @@
         "@radix-ui/react-primitive": "1.0.3",
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.5.tgz",
+      "integrity": "sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.0.3.tgz",
+      "integrity": "sha512-itYmTy/kokS21aiV5+Z56MZB54KrhPgn6eHDKkFeOLR34HMN2s8PaN47qZZAGnvupcjxHaFZnW4pQEh0BvvVuw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@radix-ui/react-hover-card": "^1.0.7",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-scroll-area": "^1.0.5",
+    "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@tanstack/react-query": "^5.28.9",
     "@tanstack/react-query-devtools": "^5.28.10",

--- a/src/app/bookMarkBox.tsx
+++ b/src/app/bookMarkBox.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+function getBookmarks(): string[] {
+  const bookmarkString = localStorage.getItem("bookmark");
+  return bookmarkString ? JSON.parse(bookmarkString) : [];
+}
+
+export default function BookMarkBox() {
+  const bookmarks = getBookmarks();
+  return (
+    <div className="h-100 w-full flex">
+      <div className="w-1/2 h-full">
+        <div className="w-full h-10 border-2 border-black">북마크</div>
+        {bookmarks.map((id) => (
+          <div key={id} className="w-full h-10 border-2 border-black">
+            {id}
+          </div>
+        ))}
+      </div>
+      <div className="w-1/2 h-full">
+        <div className="w-full h-10 border-2 border-black">검색기록</div>
+        <div className="w-full h-10 border-2 border-black">1</div>
+        <div className="w-full h-10 border-2 border-black">2</div>
+        <div className="w-full h-10 border-2 border-black">3</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/bookMarkBox.tsx
+++ b/src/app/bookMarkBox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Separator } from "@/components/ui/separator";
 import Link from "next/link";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -13,7 +15,7 @@ export default function BookMarkBox() {
   const [bookmarkArr, setBookmarkArr] = useState(getBookmarks());
 
   return (
-    <ScrollArea className="h-29 w-full rounded-md border">
+    <ScrollArea className="h-22 w-full rounded-md border">
       <div className="p-4">
         <h4 className="mb-4 flex justify-center font-medium leading-none">
           즐겨찾기

--- a/src/app/bookMarkBox.tsx
+++ b/src/app/bookMarkBox.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 function getBookmarks(): string[] {
   const bookmarkString = localStorage.getItem("bookmark");
   return bookmarkString ? JSON.parse(bookmarkString) : [];
@@ -11,11 +13,16 @@ export default function BookMarkBox() {
     <div className="h-100 w-full flex">
       <div className="w-1/2 h-full">
         <div className="w-full h-10 border-2 border-black">북마크</div>
-        {bookmarks.map((id) => (
-          <div key={id} className="w-full h-10 border-2 border-black">
-            {id}
-          </div>
-        ))}
+        {bookmarks.map((bookmark) => {
+          const [id, key] = bookmark.split("#");
+          return (
+            <Link href={`/summoner-page?id=${id}&tag=${key}`}>
+              <div className="w-full h-10 border-2 border-black">
+                {bookmark}
+              </div>
+            </Link>
+          );
+        })}
       </div>
       <div className="w-1/2 h-full">
         <div className="w-full h-10 border-2 border-black">검색기록</div>

--- a/src/app/bookMarkBox.tsx
+++ b/src/app/bookMarkBox.tsx
@@ -1,6 +1,8 @@
-"use client";
-
+import { Separator } from "@/components/ui/separator";
 import Link from "next/link";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { removeBookmarkId } from "@/lib/bookMarkFunc";
+import { useState } from "react";
 
 function getBookmarks(): string[] {
   const bookmarkString = localStorage.getItem("bookmark");
@@ -8,28 +10,39 @@ function getBookmarks(): string[] {
 }
 
 export default function BookMarkBox() {
-  const bookmarks = getBookmarks();
+  const [bookmarkArr, setBookmarkArr] = useState(getBookmarks());
+
   return (
-    <div className="h-100 w-full flex">
-      <div className="w-1/2 h-full">
-        <div className="w-full h-10 border-2 border-black">북마크</div>
-        {bookmarks.map((bookmark) => {
+    <ScrollArea className="h-29 w-full rounded-md border">
+      <div className="p-4">
+        <h4 className="mb-4 flex justify-center font-medium leading-none">
+          즐겨찾기
+        </h4>
+        {bookmarkArr.map((bookmark) => {
           const [id, key] = bookmark.split("#");
           return (
-            <Link href={`/summoner-page?id=${id}&tag=${key}`}>
-              <div className="w-full h-10 border-2 border-black">
-                {bookmark}
+            <>
+              <Separator className="my-1" />
+              <div className="flex justify-between items-center w-full">
+                <Link href={`/summoner-page?id=${id}&tag=${key}`}>
+                  <div className=" text-xs w-full h-10 flex justify-center items-center">
+                    {bookmark}
+                  </div>
+                </Link>
+                <button
+                  onClick={() => {
+                    removeBookmarkId(bookmark);
+                    setBookmarkArr(getBookmarks());
+                  }}
+                  className="text-xs"
+                >
+                  x
+                </button>
               </div>
-            </Link>
+            </>
           );
         })}
       </div>
-      <div className="w-1/2 h-full">
-        <div className="w-full h-10 border-2 border-black">검색기록</div>
-        <div className="w-full h-10 border-2 border-black">1</div>
-        <div className="w-full h-10 border-2 border-black">2</div>
-        <div className="w-full h-10 border-2 border-black">3</div>
-      </div>
-    </div>
+    </ScrollArea>
   );
 }

--- a/src/app/createSubmitHandler.tsx
+++ b/src/app/createSubmitHandler.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent } from "react";
+import { addSearchHistory } from "@/lib/searchHistoryFunc";
 
 export default function createSubmitHandler(
   inputRef: React.RefObject<HTMLInputElement>,
@@ -20,6 +21,7 @@ export default function createSubmitHandler(
 
     if (searchTerm) {
       router.push(`/summoner-page?id=${id}&tag=${tag}`);
+      addSearchHistory(`${id}#${tag}`);
       if (inputRef.current) {
         inputRef.current.value = "";
         inputRef.current.blur();

--- a/src/app/localStatusBox.tsx
+++ b/src/app/localStatusBox.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import SearchHistoryBox from "@/app/searchHistoryBox";
+import BookMarkBox from "@/app/bookMarkBox";
+
+export default function LocalStatusBox() {
+  return (
+    <div className="pt-10 h-100 w-full flex">
+      <div className="w-1/2">
+        <BookMarkBox />
+      </div>
+      <div className="w-1/2">
+        <SearchHistoryBox />
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,9 @@
 import MainSearchBar from "@/app/mainSearchBar";
+import dynamic from "next/dynamic";
+
+const BookMarkBox = dynamic(() => import("@/app/bookMarkBox"), {
+  ssr: false,
+});
 
 export default function Home() {
   return (
@@ -7,6 +12,7 @@ export default function Home() {
         mejai.gg
       </h1>
       <MainSearchBar />
+      <BookMarkBox />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,18 @@
 import MainSearchBar from "@/app/mainSearchBar";
 import dynamic from "next/dynamic";
 
-const BookMarkBox = dynamic(() => import("@/app/bookMarkBox"), {
+const LocalStatusBox = dynamic(() => import("@/app/localStatusBox"), {
   ssr: false,
 });
 
 export default function Home() {
   return (
     <div className="w-full flex flex-col items-center justify-center">
-      <h1 className="mt-36 mb-28 font-[GMARKET-Bold] text-5xl font-extrabold tracking-tight lg:text-7xl">
+      <h1 className="mt-28 mb-28 font-[GMARKET-Bold] text-5xl font-extrabold tracking-tight lg:text-7xl">
         mejai.gg
       </h1>
       <MainSearchBar />
-      <BookMarkBox />
+      <LocalStatusBox />
     </div>
   );
 }

--- a/src/app/searchHistoryBox.tsx
+++ b/src/app/searchHistoryBox.tsx
@@ -1,12 +1,49 @@
+"use client";
+
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useState } from "react";
+import { Separator } from "@/components/ui/separator";
+import Link from "next/link";
+import { removeSearchHistory } from "@/lib/searchHistoryFunc";
+
+function getSearchHistories(): string[] {
+  const searchHistoryString = localStorage.getItem("searchHistory");
+  return searchHistoryString ? JSON.parse(searchHistoryString) : [];
+}
 
 export default function SearchHistoryBox() {
+  const [searchHistoryArr, setSearchHistoryArr] =
+    useState(getSearchHistories());
   return (
     <ScrollArea className="h-29 w-full rounded-md border">
       <div className="p-4">
         <h4 className="mb-4 flex justify-center text-sm font-medium leading-none">
           검색기록
         </h4>
+        {searchHistoryArr.map((searchHistoryId) => {
+          const [id, key] = searchHistoryId.split("#");
+          return (
+            <>
+              <Separator className="my-1" />
+              <div className="flex justify-between items-center w-full">
+                <Link href={`/summoner-page?id=${id}&tag=${key}`}>
+                  <div className=" text-xs w-full h-10 flex justify-center items-center">
+                    {searchHistoryId}
+                  </div>
+                </Link>
+                <button
+                  onClick={() => {
+                    removeSearchHistory(searchHistoryId);
+                    setSearchHistoryArr(getSearchHistories());
+                  }}
+                  className="text-xs"
+                >
+                  x
+                </button>
+              </div>
+            </>
+          );
+        })}
       </div>
     </ScrollArea>
   );

--- a/src/app/searchHistoryBox.tsx
+++ b/src/app/searchHistoryBox.tsx
@@ -1,0 +1,13 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+export default function SearchHistoryBox() {
+  return (
+    <ScrollArea className="h-29 w-full rounded-md border">
+      <div className="p-4">
+        <h4 className="mb-4 flex justify-center text-sm font-medium leading-none">
+          검색기록
+        </h4>
+      </div>
+    </ScrollArea>
+  );
+}

--- a/src/app/summoner-page/LazyLoadedMonthMejaiCard.tsx
+++ b/src/app/summoner-page/LazyLoadedMonthMejaiCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useRef, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import MonthMejaiCard from "@/app/summoner-page/monthMejaiCard";

--- a/src/app/summoner-page/bookMarkButton.tsx
+++ b/src/app/summoner-page/bookMarkButton.tsx
@@ -2,35 +2,18 @@
 
 import BookMarkStar from "@/components/ui/bookMarkStar";
 import { useEffect, useState } from "react";
+import {
+  addBookmarkId,
+  isLocalStorageBookmarked,
+  removeBookmarkId,
+} from "@/lib/bookMarkFunc";
 
 interface BookMarkStarButtonProps {
   id: string;
   tag: string;
 }
 
-function addBookmarkId(id: string) {
-  const bookmarkString = localStorage.getItem("bookmark");
-  const bookmarks: string[] = bookmarkString ? JSON.parse(bookmarkString) : [];
-  if (!bookmarks.includes(id)) {
-    bookmarks.push(id);
-    localStorage.setItem("bookmark", JSON.stringify(bookmarks));
-  }
-}
-
-function removeBookmarkId(id: string) {
-  const bookmarkString = localStorage.getItem("bookmark");
-  const bookmarks: string[] = bookmarkString ? JSON.parse(bookmarkString) : [];
-  const filteredBookmarks = bookmarks.filter((bookmarkId) => bookmarkId !== id);
-  localStorage.setItem("bookmark", JSON.stringify(filteredBookmarks));
-}
-
-function isLocalStorageBookmarked(id: string): boolean {
-  const bookmarkString = localStorage.getItem("bookmark");
-  const bookmarks: string[] = bookmarkString ? JSON.parse(bookmarkString) : [];
-  return bookmarks.includes(id);
-}
-
-function toggleBookMark(
+export function toggleBookMark(
   isBookMarked: boolean,
   setIsBookMarked: Function,
   id: string,

--- a/src/app/summoner-page/bookMarkButton.tsx
+++ b/src/app/summoner-page/bookMarkButton.tsx
@@ -1,0 +1,75 @@
+import BookMarkStar from "@/components/ui/bookMarkStar";
+import { useEffect, useState } from "react";
+
+interface BookMarkStarButtonProps {
+  id: string;
+  tag: string;
+}
+
+function addBookmarkId(id: string) {
+  const bookmarkString = localStorage.getItem("bookmark");
+  const bookmarks: string[] = bookmarkString ? JSON.parse(bookmarkString) : [];
+  if (!bookmarks.includes(id)) {
+    bookmarks.push(id);
+    localStorage.setItem("bookmark", JSON.stringify(bookmarks));
+  }
+}
+
+function removeBookmarkId(id: string) {
+  const bookmarkString = localStorage.getItem("bookmark");
+  const bookmarks: string[] = bookmarkString ? JSON.parse(bookmarkString) : [];
+  const filteredBookmarks = bookmarks.filter((bookmarkId) => bookmarkId !== id);
+  localStorage.setItem("bookmark", JSON.stringify(filteredBookmarks));
+}
+
+function isLocalStorageBookmarked(id: string): boolean {
+  const bookmarkString = localStorage.getItem("bookmark");
+  const bookmarks: string[] = bookmarkString ? JSON.parse(bookmarkString) : [];
+  return bookmarks.includes(id);
+}
+
+function toggleBookMark(
+  isBookMarked: boolean,
+  setIsBookMarked: Function,
+  id: string,
+  tag: string,
+) {
+  // 북마크 상태를 토글하는 함수
+
+  if (isBookMarked) {
+    // 북마크를 해제하는 경우
+    removeBookmarkId(`${id}#${tag}`);
+  } else {
+    // 북마크를 추가하는 경우
+    addBookmarkId(`${id}#${tag}`);
+  }
+  setIsBookMarked(!isBookMarked);
+}
+
+export default function BookMarkButton({ id, tag }: BookMarkStarButtonProps) {
+  const [isBookMarked, setIsBookMarked] = useState(
+    isLocalStorageBookmarked(`${id}#${tag}`),
+  );
+
+  useEffect(() => {
+    // 다른 탭에서 북마크를 추가하거나 삭제한 경우 북마크 상태를 업데이트
+    function updateBookmarkStatus() {
+      setIsBookMarked(isLocalStorageBookmarked(`${id}#${tag}`));
+    }
+    window.addEventListener("storage", updateBookmarkStatus);
+    return () => {
+      window.removeEventListener("storage", updateBookmarkStatus);
+    };
+  }, [id, tag]);
+
+  return (
+    <button
+      onClick={() => {
+        toggleBookMark(isBookMarked, setIsBookMarked, id, tag);
+      }}
+      className="w-fit h-fit ml-2"
+    >
+      <BookMarkStar isFilled={isBookMarked} />
+    </button>
+  );
+}

--- a/src/app/summoner-page/bookMarkButton.tsx
+++ b/src/app/summoner-page/bookMarkButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import BookMarkStar from "@/components/ui/bookMarkStar";
 import { useEffect, useState } from "react";
 

--- a/src/app/summoner-page/fetchFunc.tsx
+++ b/src/app/summoner-page/fetchFunc.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import axios from "axios";
 import { SERVER_URL } from "@/lib/utils";
 import { DayGameData } from "@/app/summoner-page/monthMejaiCard";

--- a/src/app/summoner-page/monthMejaiCard.tsx
+++ b/src/app/summoner-page/monthMejaiCard.tsx
@@ -18,9 +18,11 @@ function updateGameCountForMonth(
   inputData: DayGameData[],
   year: number,
   month: number,
+  setSumOfGameCount: (value: number) => void,
 ) {
   const startOfMonth = dayjs(new Date(year, month - 1, 1));
   const endOfMonth = dayjs(new Date(year, month, 0));
+  let sumOfGameCount = 0;
 
   let daysArray: DayGameData[] = [];
   let day = startOfMonth;
@@ -39,10 +41,11 @@ function updateGameCountForMonth(
     const index = daysArray.findIndex((day) => day.date === data.date);
     if (index !== -1) {
       daysArray[index].gameCount = data.gameCount;
+      sumOfGameCount += data.gameCount;
       daysArray[index].imageUrl = data.imageUrl;
     }
   });
-
+  setSumOfGameCount(sumOfGameCount);
   return daysArray;
 }
 
@@ -69,6 +72,7 @@ export default function MonthMejaiCard({ month }: MonthMejaiCardProps) {
   const id = params.get("id") || "";
   const tag = params.get("tag") || "";
   let year = 2024;
+  const [sumOfGameCount, setSumOfGameCount] = useState(0);
 
   const { data, error, isLoading } = useQuery<DayGameData[]>({
     queryKey: ["jandi", { id, tag, year: 2024, month: month }],
@@ -79,7 +83,12 @@ export default function MonthMejaiCard({ month }: MonthMejaiCardProps) {
 
   useEffect(() => {
     if (data) {
-      const updatedData = updateGameCountForMonth(data, year, month);
+      const updatedData = updateGameCountForMonth(
+        data,
+        year,
+        month,
+        setSumOfGameCount,
+      );
       setMonthData(updatedData);
     }
   }, [data]);
@@ -107,6 +116,7 @@ export default function MonthMejaiCard({ month }: MonthMejaiCardProps) {
       <span className="text-2xl font-semibold mt-4 mb-4">
         {year}년 {month}월
       </span>
+      <span className="mb-2">총 {sumOfGameCount}게임</span>
       <WeekDays />
       <div className="grid grid-cols-7 gap-1 w-full">
         {emptyBlocks}

--- a/src/app/summoner-page/shareButton.tsx
+++ b/src/app/summoner-page/shareButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Popover,
   PopoverContent,

--- a/src/app/summoner-page/shareButton.tsx
+++ b/src/app/summoner-page/shareButton.tsx
@@ -1,0 +1,40 @@
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import ShareSvgIcon from "@/components/ui/shareSvgIcon";
+import { useEffect, useState } from "react";
+
+const copyUrl = () => {
+  navigator.clipboard.writeText(window.location.href);
+};
+
+export default function ShareButton() {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+
+  useEffect(() => {
+    // 팝오버 닫기 타임아웃 이벤트
+    if (popoverOpen) {
+      const timer = setTimeout(() => {
+        setPopoverOpen(false);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [popoverOpen]);
+
+  return (
+    <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+      <PopoverTrigger asChild>
+        <button onClick={copyUrl} className="w-fit h-fit">
+          <ShareSvgIcon />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div className="font-medium flex justify-center items-center">
+          클립보드에 url이 복사되었습니다
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/app/summoner-page/userInfoBox.tsx
+++ b/src/app/summoner-page/userInfoBox.tsx
@@ -70,7 +70,7 @@ export default function UserInfoBox({ id, tag }: TierBoxProps) {
           {data.userName}
           <span className="font-medium text-gray-500"> #{data.tagLine}</span>
         </h1>
-        <div className="flex items-center">
+        <div className="flex items-center mt-2">
           <ShareButton />
           <BookMarkButton id={id} tag={tag} />
         </div>

--- a/src/app/summoner-page/userInfoBox.tsx
+++ b/src/app/summoner-page/userInfoBox.tsx
@@ -1,18 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import Image from "next/image";
 import { useQuery } from "@tanstack/react-query";
 import { fetchUserInfo } from "@/app/summoner-page/fetchFunc";
 import { AxiosError } from "axios";
-import ShareSvgIcon from "@/components/ui/shareSvgIcon";
-
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import ShareButton from "@/app/summoner-page/shareButton";
+import BookMarkButton from "@/app/summoner-page/bookMarkButton";
 
 function ImageSkeleton() {
   return (
@@ -37,21 +31,6 @@ export default function UserInfoBox({ id, tag }: TierBoxProps) {
     staleTime: 1000 * 60 * 15, // 15분으로 staletime 설정
     gcTime: 1000 * 60 * 15,
   });
-
-  const copyUrl = () => {
-    navigator.clipboard.writeText(window.location.href);
-  };
-
-  const [popoverOpen, setPopoverOpen] = useState(false);
-
-  useEffect(() => {
-    if (popoverOpen) {
-      const timer = setTimeout(() => {
-        setPopoverOpen(false);
-      }, 1000);
-      return () => clearTimeout(timer);
-    }
-  }, [popoverOpen]);
 
   if (isLoading)
     return (
@@ -91,18 +70,10 @@ export default function UserInfoBox({ id, tag }: TierBoxProps) {
           {data.userName}
           <span className="font-medium text-gray-500"> #{data.tagLine}</span>
         </h1>
-        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-          <PopoverTrigger asChild>
-            <button onClick={copyUrl} className="w-fit h-fit">
-              <ShareSvgIcon />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent>
-            <div className="font-medium flex justify-center items-center">
-              클립보드에 url이 복사되었습니다
-            </div>
-          </PopoverContent>
-        </Popover>
+        <div className="flex items-center">
+          <ShareButton />
+          <BookMarkButton id={id} tag={tag} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/bookMarkStar.tsx
+++ b/src/components/ui/bookMarkStar.tsx
@@ -1,0 +1,39 @@
+interface BookMarkStarProps {
+  isFilled: boolean;
+}
+
+export default function BookMarkStar({ isFilled }: BookMarkStarProps) {
+  if (isFilled) {
+    return (
+      <svg
+        className="w-6 h-6 text-gray-800 dark:text-white"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path d="M13.849 4.22c-.684-1.626-3.014-1.626-3.698 0L8.397 8.387l-4.552.361c-1.775.14-2.495 2.331-1.142 3.477l3.468 2.937-1.06 4.392c-.413 1.713 1.472 3.067 2.992 2.149L12 19.35l3.897 2.354c1.52.918 3.405-.436 2.992-2.15l-1.06-4.39 3.468-2.938c1.353-1.146.633-3.336-1.142-3.477l-4.552-.36-1.754-4.17Z" />
+      </svg>
+    );
+  } else {
+    return (
+      <svg
+        className="w-6 h-6 text-gray-800 dark:text-white"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke="currentColor"
+          strokeWidth="2"
+          d="M11.083 5.104c.35-.8 1.485-.8 1.834 0l1.752 4.022a1 1 0 0 0 .84.597l4.463.342c.9.069 1.255 1.2.556 1.771l-3.33 2.723a1 1 0 0 0-.337 1.016l1.03 4.119c.214.858-.71 1.552-1.474 1.106l-3.913-2.281a1 1 0 0 0-1.008 0L7.583 20.8c-.764.446-1.688-.248-1.474-1.106l1.03-4.119A1 1 0 0 0 6.8 14.56l-3.33-2.723c-.698-.571-.342-1.702.557-1.771l4.462-.342a1 1 0 0 0 .84-.597l1.753-4.022Z"
+        />
+      </svg>
+    );
+  }
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/src/components/ui/shareSvgIcon.tsx
+++ b/src/components/ui/shareSvgIcon.tsx
@@ -1,20 +1,15 @@
 export default function ShareSvgIcon() {
   return (
     <svg
-      className="w-[28px] h-[28px] text-gray-800 dark:text-white"
+      className="w-6 h-6 text-gray-800 dark:text-white"
       aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
       width="24"
       height="24"
-      fill="none"
+      fill="currentColor"
       viewBox="0 0 24 24"
     >
-      <path
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeWidth="1.9"
-        d="M7.926 10.898 15 7.727m-7.074 5.39L15 16.29M8 12a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm12 5.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm0-11a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Z"
-      />
+      <path d="M17.5 3a3.5 3.5 0 0 0-3.456 4.06L8.143 9.704a3.5 3.5 0 1 0-.01 4.6l5.91 2.65a3.5 3.5 0 1 0 .863-1.805l-5.94-2.662a3.53 3.53 0 0 0 .002-.961l5.948-2.667A3.5 3.5 0 1 0 17.5 3Z" />
     </svg>
   );
 }

--- a/src/lib/bookMarkFunc.ts
+++ b/src/lib/bookMarkFunc.ts
@@ -1,0 +1,21 @@
+export function addBookmarkId(id: string) {
+  const bookmarkString = localStorage.getItem("bookmark");
+  const bookmarks: string[] = bookmarkString ? JSON.parse(bookmarkString) : [];
+  if (!bookmarks.includes(id)) {
+    bookmarks.unshift(id);
+    localStorage.setItem("bookmark", JSON.stringify(bookmarks));
+  }
+}
+
+export function removeBookmarkId(id: string) {
+  const bookmarkString = localStorage.getItem("bookmark");
+  const bookmarks: string[] = bookmarkString ? JSON.parse(bookmarkString) : [];
+  const filteredBookmarks = bookmarks.filter((bookmarkId) => bookmarkId !== id);
+  localStorage.setItem("bookmark", JSON.stringify(filteredBookmarks));
+}
+
+export function isLocalStorageBookmarked(id: string): boolean {
+  const bookmarkString = localStorage.getItem("bookmark");
+  const bookmarks: string[] = bookmarkString ? JSON.parse(bookmarkString) : [];
+  return bookmarks.includes(id);
+}

--- a/src/lib/searchHistoryFunc.ts
+++ b/src/lib/searchHistoryFunc.ts
@@ -1,0 +1,33 @@
+export function addSearchHistory(id: string) {
+  const searchHistoryString = localStorage.getItem("searchHistory");
+  const searchHistories: string[] = searchHistoryString
+    ? JSON.parse(searchHistoryString)
+    : [];
+  if (!searchHistories.includes(id)) {
+    searchHistories.unshift(id);
+    if (searchHistories.length > 10) searchHistories.pop();
+    localStorage.setItem("searchHistory", JSON.stringify(searchHistories));
+  }
+}
+
+export function removeSearchHistory(id: string) {
+  const searchHistoryString = localStorage.getItem("searchHistory");
+  const searchHistories: string[] = searchHistoryString
+    ? JSON.parse(searchHistoryString)
+    : [];
+  const filteredSearchHistories = searchHistories.filter(
+    (searchHistoryId) => searchHistoryId !== id,
+  );
+  localStorage.setItem(
+    "searchHistory",
+    JSON.stringify(filteredSearchHistories),
+  );
+}
+
+export function isSearchHistory(id: string): boolean {
+  const searchHistoryString = localStorage.getItem("searchHistory");
+  const searchHistories: string[] = searchHistoryString
+    ? JSON.parse(searchHistoryString)
+    : [];
+  return searchHistories.includes(id);
+}


### PR DESCRIPTION
## ✅ 풀\_리퀘스트 체크리스트

<!--
하나씩 확인 후 체크박스에 표시해주세요.
-->

- [x] PR 제목: [Feature/Fix/Refactor...] 작업 내용 한 줄 요약 (브랜치 이름) #이슈번호
- [x] commit message 가 적절한지 확인해주세요.
- [x] 적절한 branch 로 요청했는지 확인해주세요.
- [x] Assignees, Label 을 붙여주세요.
- [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer 로 등록해주세요.
- [ ] PR이 승인된 경우 해당 브랜치는 삭제해 주세요!

<br/>

## 🔄 변경 사항


https://github.com/mejaiGG/Frontend/assets/81581828/caf08f48-6030-4e44-b1a7-5eef07000fb8

suspense에 대한 이해
- useSearchParams 사용 컴포넌트를 suspense로 감싸서 csr 해줬었습니다. (https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)
하지만 정확히 왜 csr이 되는지 이해하진 못했었습니다. 반성..
suspense경계로 감싸진 컴포넌트는 자식 컴포넌트의 비동기 작업이 완료되기 전까지 fallback ui를 보여줍니다.
리액트 훅 같이 클라이언트사이드에서만 실행 가능한 로직의 경우 서버사이드에선 완료되지 않으므로 ssg환경에서 suspense태그로 감싸면 전부 csr하게 되는 것 입니다. 이해완
재밌는건 suspense로 감싸서 csr하게 된 컴포넌트는 해당 파일 상단에 'use client'를 명시하지 않아도 훅 사용 에러가 발생하지 않습니다 (똘똘이 next ㄷㄷ)

총 게임 보여주기 추가
- useEffect콜백함수는 render()호출 이후에 일어나므로 뷰에 업데이트해주기 위해 state로 관리했습니다. 
- 더 좋은 방식 있으면 리뷰 부탁드림

북마크 기능 추가
- 북마크 useState를  Lazy initialization 사용해서 localstorage 정보 받아온 다음에 만들어줌
- main화면에서 북마크 리스트 보이게 해놨습니다.
- 해당 리스트 링크, 삭제버튼 추가했습니다.

검색 기록 기능 추가
- 북마크 기능이랑 대부분 비슷합니다.
- 최대 10개까지 쌓이고 11개부터 이전 기록 pop하게 해줬습니다


<br/>

<!-- 관련되어있는 Issue Number 를 작성하세요! 해당 이슈를 이곳에 적으면 pr merge 이후 해당 이슈는 자동으로 close 됩니다. -->

closes: #15
